### PR TITLE
Add feeds for blog post

### DIFF
--- a/bitebybits/blog/feeds.py
+++ b/bitebybits/blog/feeds.py
@@ -1,0 +1,22 @@
+from django.contrib.syndication.views import Feed
+from django.template.defaultfilters import truncatewords
+from .models import Post
+
+
+class LatestPostFeed(Feed):
+    """
+    Django built-in syndication feed framework to generate
+    RSS or Atom feeds.
+    """
+    title = 'Bite by Bits - Blog'
+    link = '/blog/'
+    description = 'New post on Bite by Bits!'
+
+    def items(self):
+        return Post.published.all()[:3]
+
+    def item_title(self, item):
+        return item.title
+
+    def item_description(self, item):
+        return truncatewords(item.body, 30)

--- a/bitebybits/blog/templates/blog/footer.html
+++ b/bitebybits/blog/templates/blog/footer.html
@@ -5,10 +5,10 @@
                 <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
                     <ul class="list-inline text-center">
                         <li>
-                            <a href="#">
+                            <a href="{% url 'blog:post_feed' %}">
                                 <span class="fa-stack fa-lg">
                                     <i class="fa fa-circle fa-stack-2x"></i>
-                                    <i class="fa fa-twitter fa-stack-1x fa-inverse"></i>
+                                    <i class="fa fa-rss fa-stack-1x fa-inverse"></i>
                                 </span>
                             </a>
                         </li>

--- a/bitebybits/blog/urls.py
+++ b/bitebybits/blog/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import url
 
+from .feeds import LatestPostFeed
 from . import views
 
 
@@ -11,5 +12,10 @@ urlpatterns = [
     url(r'^(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})/(?P<post>[-\w]+)/$',
         views.post_detail,
         name='post_detail'),
+
+    # Feeds
+    url(r'^feed/$',
+        LatestPostFeed(),
+        name='post_feed'),
 
 ]


### PR DESCRIPTION
Creating feeds for blog posts, django comes with a high-level syndication-feed-generating framework that makes creating RSS and Atom easy. Added link subscription to the footer 