### PR TITLE
Install sitemap framework

### DIFF
--- a/bitebybits/bitebybits/urls.py
+++ b/bitebybits/bitebybits/urls.py
@@ -1,27 +1,25 @@
-"""bitebybits URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.11/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.conf.urls import url, include
-    2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
-"""
 from django.conf.urls import include, url
 from django.contrib import admin
+from django.contrib.sitemaps.views import sitemap
+from blog.sitemaps import PostSitemap
+
 from django.conf import settings
 from django.conf.urls.static import static
 
 from blog import views
 
+
+sitemaps = {
+    'posts': PostSitemap,
+}
+
+
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
+
+    # sitemap generator
+    url(r'^sitemap\.xml$', sitemap, {'sitemaps': sitemaps},
+        name='django.contrib.sitemaps.views.sitemap'),
 
     url(r'^blog/', include('blog.urls',
                            namespace='blog',

--- a/bitebybits/blog/sitemaps.py
+++ b/bitebybits/blog/sitemaps.py
@@ -1,0 +1,15 @@
+from django.contrib.sitemaps import Sitemap
+from .models import Post
+
+
+class PostSitemap(Sitemap):
+    # Change frequency
+    changefreq = 'monthly'
+    # max=1
+    priority = 0.9
+
+    def items(self):
+        return Post.published.all()
+
+    def lastmod(self, obj):
+        return obj.publish


### PR DESCRIPTION
The sitemap framework
Django comes with a high-level sitemap-generating framework that makes creating sitemap XML files easy.
A sitemap is an XML file on website that tells search-engine indexers how frequently pages change and how “important” certain pages are in relation to other pages on the site. This information helps search engines index of site.
For PRODUCTION ENVIRONMENT  **http://127.0.0.1:8000**/admin/sites/site/ have to be change for proper domain(i.e  127.0.0.1:8000 --> example.com)